### PR TITLE
Add support for heartcheck 1.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.7
-  - 2.2.4
-  - 2.3.0
 install: bundle install -j 4 --retry 3
 script:
   - RAILS_ENV=test bundle exec rspec spec
 services:
   - redis-server
+
+matrix:
+  include:
+    - rvm: "1.9.3"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.0.0"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.1.0"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.1.5"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.2.1"
+      gemfile: Gemfile-old-ruby
+    - rvm: "2.2.2"
+    - rvm: "2.3.0"
+    - rvm: "2.3.3"
+    - rvm: "2.4.1"

--- a/Gemfile-old-ruby
+++ b/Gemfile-old-ruby
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'net-telnet', '~> 0.1.1'
+gem 'heartcheck', '>= 1.0.0'
+gem 'redis', '>= 3.2.0', '< 3.4.0'
+gem 'sidekiq', '~> 2.0.0'
+gem 'rack', '~> 1.6'
+gem 'rspec', '~> 3.1.0', '>= 3.1.0'
+gem 'pry-nav', '~> 0.2.0', '>= 0.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    heartcheck-sidekiq (0.0.1)
-      heartcheck (~> 1.0.0, >= 1.0.0)
+    heartcheck-sidekiq (0.1.0)
+      heartcheck (~> 1.0, >= 1.0.0)
       net-telnet (~> 0.1.1)
       sidekiq (>= 2.0.0)
 
@@ -12,20 +12,17 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    celluloid (0.16.0)
-      timers (~> 4.0.0)
     coderay (1.1.0)
-    connection_pool (2.2.0)
+    concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     diff-lcs (1.2.5)
-    heartcheck (1.0.9)
+    heartcheck (1.2.2)
+      multi_json (~> 1.0)
       net-telnet (~> 0.1.1)
-      oj
-      rack (~> 1, >= 1.4.0)
-    hitimes (1.2.3)
-    json (1.8.3)
+      rack (>= 1.4.0, < 2.1)
     method_source (0.8.2)
+    multi_json (1.12.1)
     net-telnet (0.1.1)
-    oj (2.14.5)
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
     powerpack (0.0.9)
@@ -35,12 +32,12 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    rack (1.6.4)
+    rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
     rainbow (2.0.0)
     redcarpet (3.2.2)
-    redis (3.2.2)
-    redis-namespace (1.5.2)
-      redis (~> 3.0, >= 3.0.4)
+    redis (3.3.3)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -60,15 +57,12 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.1)
-    sidekiq (3.4.1)
-      celluloid (~> 0.16.0)
-      connection_pool (>= 2.1.1)
-      json
-      redis (>= 3.0.6)
-      redis-namespace (>= 1.3.1)
+    sidekiq (5.0.4)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.3, >= 3.3.3)
     slop (3.6.0)
-    timers (4.0.4)
-      hitimes
     yard (0.8.7.6)
 
 PLATFORMS
@@ -83,4 +77,4 @@ DEPENDENCIES
   yard (~> 0.8.0, >= 0.8.7)
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/heartcheck-sidekiq.gemspec
+++ b/heartcheck-sidekiq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
 
-  spec.add_dependency 'heartcheck', '~> 1.0.0', '>= 1.0.0'
+  spec.add_dependency 'heartcheck', '~> 1.0', '>= 1.0.0'
   spec.add_dependency 'sidekiq', '>= 2.0.0'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'

--- a/lib/heartcheck/sidekiq/version.rb
+++ b/lib/heartcheck/sidekiq/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Sidekiq
-    VERSION = '0.0.1'
+    VERSION = '0.1.0'
   end
 end


### PR DESCRIPTION
<b> Why </b>

Due to a restriction in this `gemspec` it's not possible to update heartcheck to the newest version. 

<b> What </b>

Remove the patch from the requirements params and bump the heartcheck version.
