### PR TITLE
Use top namespace to prevent redis constant error

### DIFF
--- a/lib/heartcheck/checks/sidekiq.rb
+++ b/lib/heartcheck/checks/sidekiq.rb
@@ -12,7 +12,7 @@ module Heartcheck
           append_error(:get) unless get?(connection)
           append_error(:delete) unless del?(connection)
         end
-      rescue Redis::BaseError
+      rescue ::Redis::BaseError
         append_error('connect to redis')
       rescue => e
         @errors << "Sidekiq error: #{e.message}"

--- a/lib/heartcheck/sidekiq/version.rb
+++ b/lib/heartcheck/sidekiq/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Sidekiq
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'.freeze
   end
 end


### PR DESCRIPTION
This PR solves https://github.com/locaweb/heartcheck-sidekiq/issues/6 .