### PR TITLE
Update rubocop and yard

### DIFF
--- a/Gemfile-old-ruby
+++ b/Gemfile-old-ruby
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'net-telnet', '~> 0.1.1'
 gem 'heartcheck', '>= 1.0.0'
 gem 'redis', '>= 3.2.0', '< 3.4.0'
 gem 'sidekiq', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,31 @@
 PATH
   remote: .
   specs:
-    heartcheck-sidekiq (0.1.0)
+    heartcheck-sidekiq (0.1.1)
       heartcheck (~> 1.0, >= 1.0.0)
-      net-telnet (~> 0.1.1)
       sidekiq (>= 2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    ast (2.3.0)
     coderay (1.1.0)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     diff-lcs (1.2.5)
-    heartcheck (1.2.2)
+    ffi (1.9.18)
+    heartcheck (1.4.0)
       multi_json (~> 1.0)
       net-telnet (~> 0.1.1)
       rack (>= 1.4.0, < 2.1)
+      sys-uname (~> 1.0, >= 1.0.3)
     method_source (0.8.2)
-    multi_json (1.12.1)
+    multi_json (1.13.0)
     net-telnet (0.1.1)
-    parser (2.2.0.3)
-      ast (>= 1.1, < 3.0)
-    powerpack (0.0.9)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -35,9 +35,11 @@ GEM
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
-    rainbow (2.0.0)
+    rainbow (2.2.2)
+      rake
+    rake (12.3.0)
     redcarpet (3.2.2)
-    redis (3.3.3)
+    redis (4.0.1)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -50,20 +52,24 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    rubocop (0.27.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.0.pre.7, < 3.0)
-      powerpack (~> 0.0.6)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.1)
-    sidekiq (5.0.4)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    sidekiq (5.0.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (~> 3.3, >= 3.3.3)
+      redis (>= 3.3.4, < 5)
     slop (3.6.0)
-    yard (0.8.7.6)
+    sys-uname (1.0.3)
+      ffi (>= 1.0.0)
+    unicode-display_width (1.3.0)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -73,8 +79,8 @@ DEPENDENCIES
   pry-nav (~> 0.2.0, >= 0.2.4)
   redcarpet (~> 3.2.0, >= 3.2.2)
   rspec (~> 3.1.0, >= 3.1.0)
-  rubocop (~> 0.27.0, >= 0.27.1)
-  yard (~> 0.8.0, >= 0.8.7)
+  rubocop (~> 0.49.0)
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.13.7
+   1.16.0

--- a/heartcheck-sidekiq.gemspec
+++ b/heartcheck-sidekiq.gemspec
@@ -17,15 +17,13 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'net-telnet', '~> 0.1.1'
-
   spec.add_dependency 'heartcheck', '~> 1.0', '>= 1.0.0'
   spec.add_dependency 'sidekiq', '>= 2.0.0'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'
   spec.add_development_dependency 'rspec', '~> 3.1.0', '>= 3.1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.27.0', '>= 0.27.1'
+  spec.add_development_dependency 'rubocop', '~> 0.49.0'
   # for documentation
-  spec.add_development_dependency 'yard', '~> 0.8.0', '>= 0.8.7'
+  spec.add_development_dependency 'yard', '~> 0.9.11'
   spec.add_development_dependency 'redcarpet', '~> 3.2.0', '>= 3.2.2'
 end

--- a/lib/heartcheck/sidekiq/version.rb
+++ b/lib/heartcheck/sidekiq/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Sidekiq
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.1.2'.freeze
   end
 end


### PR DESCRIPTION
* Resolve vulnerability warning for Rubocop and Yard
* Remove telnet dependency, as it is not used in this plugin