### PR TITLE
Bumping heartcheck version

### DIFF
--- a/heartcheck-sidekiq.gemspec
+++ b/heartcheck-sidekiq.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'heartcheck', '~> 1.0', '>= 1.0.0'
+  spec.add_dependency 'heartcheck', '~> 2.0', '>= 2.0.0'
   spec.add_dependency 'sidekiq', '>= 2.0.0', '< 6.0.0'
 
   spec.add_development_dependency 'pry-nav', '~> 0.2.0', '>= 0.2.4'


### PR DESCRIPTION
Bumping version to work with `rack (~> 2.0, >= 2.0.8)` (`rails (~> 6.0.3, >= 6.0.3.2)`)