### PR TITLE
Update dependency version due vulnerability and adds changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,24 @@
+# Heartcheck Sidekiq - Changelog
+
+== Version 0.2.0 :: 2021-03-02
+* Dropped support for ruby < 2.5 (EOL);
+* Removed limit for maximum sidekiq version due no compatibility break since
+2.0.
+
+== Version 0.1.3 :: 2021-02-17
+* Bump heartcheck's version to 2.0.0;
+* Increase ruby support for 2.6;
+* Minor improvements, abstracted to a separate module the redis validations.
+
+== Version 0.1.2 :: 2019-02-19
+* Update Rubucop and Yard version.
+
+== Version 0.1.1 :: 2017-10-20
+* Minor fix in namespace of Redis to prevent ConstantError;
+* Added ebert.yml to project.
+
+== Version 0.1.0 :: 2017-08-30
+* Added support for heartcheck 1.2.2.
+
+== Version 0.0.1 :: 2015-05-12
+* Initial release.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@
 == Version 0.2.0 :: 2021-03-02
 * Dropped support for ruby < 2.5 (EOL);
 * Removed limit for maximum sidekiq version due no compatibility break since
-2.0.
+2.0;
+* Update vulnerable dependecy (CVE-2020-26298).
 
 == Version 0.1.3 :: 2021-02-17
 * Bump heartcheck's version to 2.0.0;

--- a/heartcheck-sidekiq.gemspec
+++ b/heartcheck-sidekiq.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.49.0'
   # for documentation
   spec.add_development_dependency 'yard', '~> 0.9.11'
-  spec.add_development_dependency 'redcarpet', '~> 3.2.0', '>= 3.2.2'
+  spec.add_development_dependency 'redcarpet', '~> 3.5.0', '>= 3.5.1'
 
   spec.required_ruby_version = '>= 2.5'
 end

--- a/lib/heartcheck/sidekiq/version.rb
+++ b/lib/heartcheck/sidekiq/version.rb
@@ -2,6 +2,6 @@
 module Heartcheck
   # gem version
   module Sidekiq
-    VERSION = '0.1.3'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
This MR adds requirement for redcarpet to version `3.5.1` due to Injection/XSS vulnerability. (See CVE-2020-26298)

And I've added the CHANGELOG to application to keep on track further changes in `heartcheck-sidekiq` gem.